### PR TITLE
Fixes #299: typo on line Event/polyfill-ie8.js:99

### DIFF
--- a/polyfills/Event/polyfill-ie8.js
+++ b/polyfills/Event/polyfill-ie8.js
@@ -96,7 +96,7 @@
 		var
 		element = this,
 		type = arguments[0],
-		listener = arguments[1].
+		listener = arguments[1],
 		index;
 
 		if (element._events && element._events[type] && element._events[type].list) {


### PR DESCRIPTION
Currently this function attempts to grab the index property of the second argument, and leaves the index variable un-scoped. Fixing the typo makes it behave properly.
